### PR TITLE
Feature/add severity filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "locked-in"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "colored",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locked-in"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -147,7 +147,70 @@ locked-in
 locked-in /path/to/repo
 ```
 
-Exit code 0 on success, 1 if violations found.
+Exit code 0 on success, 1 if it should fail (see below), 2 on invalid arguments.
+
+#### Options
+
+| Flag | Behavior |
+|---|---|
+| `-q`, `--quiet` | Suppress warning lines from output. Errors and the summary are still printed. Exit code unchanged. |
+| `--max-warnings <N>` | Exit non-zero if the warning count exceeds `N`. Defaults to unlimited (warnings never fail the run). |
+| `--fail-on <level>` | One of `error` (default) or `warning`. `--fail-on warning` is equivalent to `--max-warnings 0`. |
+| `--format <fmt>` | Output format: `text` (default) or `json`. |
+| `--no-summary` | Skip the trailing `═══ Found N violation(s) ═══` summary block (text format only). |
+| `-h`, `--help` | Show help. |
+| `-V`, `--version` | Show version. |
+
+Errors always fail the run (exit `1`). Warnings only affect the exit code when a threshold is set
+via `--max-warnings` or `--fail-on warning`; when both are given, the stricter (lower) threshold
+applies. The flags compose — e.g. `--quiet --max-warnings 0` shows only errors but still fails on
+any warning.
+
+#### Output streams
+
+Findings are written to **stdout**; the progress line and the summary block are written to
+**stderr**. This means `locked-in . > findings.txt` captures only the findings, leaving the
+chrome on the terminal. The exit code is unaffected by which stream output goes to, and by a
+broken downstream pipe (e.g. `locked-in . | head` exits cleanly rather than panicking).
+
+#### JSON output
+
+`--format json` writes a single JSON document to stdout (no progress/summary chrome, so the
+output is always valid JSON). Counts always reflect the full scan; `--quiet` still filters
+warnings out of the per-file arrays, and `--no-summary` has no effect in this mode. `files`
+lists only files with findings, so `files.length` is not necessarily `files_checked`. The
+`schema_version` field is bumped on any breaking change to this shape.
+
+```json
+{
+  "schema_version": 1,
+  "files_checked": 8,
+  "violations_found": 1,
+  "warnings_found": 1,
+  "files": [
+    {
+      "path": "Dockerfile",
+      "violations": [
+        {
+          "severity": "error",
+          "rule_id": "npm-install-bare",
+          "line": 15,
+          "message": "Use 'npm ci' instead of 'npm install' for lockfile-based installations",
+          "line_content": "RUN npm install"
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### CI tuning
+
+| Goal | Flags |
+|---|---|
+| Errors-only display, fail on errors (default behavior, quieter log) | `--quiet` |
+| Errors-only display, fail on errors **or** warnings | `--quiet --max-warnings 0` |
+| Full display, fail on errors **or** warnings | `--max-warnings 0` |
 
 ## Dependency Cooldowns
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,150 @@
 use crate::lint_files;
+use crate::report::{render_json, render_text};
+use crate::{EXIT_FINDINGS, EXIT_SUCCESS, EXIT_USAGE, LintResult, output};
 use colored::Colorize;
+use std::io::{self, Write};
 use std::path::PathBuf;
 
-const USAGE: &str = "Usage: locked-in [PATH]\n\nLints package-manager commands for lockfile and version-pin safety.\n\nArguments:\n  PATH        Repository path to scan (default: current directory)\n\nOptions:\n  -h, --help     Show this help text\n  -V, --version  Show version\n";
+const USAGE: &str = "Usage: locked-in [OPTIONS] [PATH]\n\nLints package-manager commands for lockfile and version-pin safety.\n\nArguments:\n  PATH        Repository path to scan (default: current directory)\n\nOptions:\n  -q, --quiet            Suppress warning lines from output; errors and summary still print\n                         (e.g. locked-in --quiet .)\n      --max-warnings <N>  Exit non-zero if warning count exceeds N; default: unlimited\n                         (e.g. locked-in --max-warnings 0 .)\n      --fail-on <level>   Exit non-zero threshold: 'error' (default) or 'warning';\n                         '--fail-on warning' is equivalent to '--max-warnings 0'\n                         (e.g. locked-in --fail-on warning .)\n      --format <fmt>     Output format: 'text' (default) or 'json'\n                         (e.g. locked-in --format json .)\n      --no-summary       Skip the trailing summary block (text format only)\n                         (e.g. locked-in --no-summary .)\n  -h, --help             Show this help text\n  -V, --version          Show version\n\nFindings are written to stdout; progress and the summary are written to stderr.";
+
+const DIVIDER: &str = "═══════════════════════════════════════";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FailLevel {
+    Error,
+    Warning,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutputFormat {
+    Text,
+    Json,
+}
+
+struct Options {
+    root: PathBuf,
+    quiet: bool,
+    no_summary: bool,
+    max_warnings: Option<usize>,
+    fail_on: FailLevel,
+    format: OutputFormat,
+}
+
+/// Resolve the effective warning threshold from `--max-warnings` and `--fail-on`.
+/// `--fail-on warning` is equivalent to `--max-warnings 0`; when both are present the
+/// strictest (lowest) threshold wins.
+fn effective_max_warnings(max_warnings: Option<usize>, fail_on: FailLevel) -> Option<usize> {
+    let fail_on_threshold = match fail_on {
+        FailLevel::Warning => Some(0),
+        FailLevel::Error => None,
+    };
+    [max_warnings, fail_on_threshold].into_iter().flatten().min()
+}
+
+/// Compute the process exit code. Errors always fail; warnings fail only when they exceed
+/// the effective threshold.
+fn exit_code(errors: usize, warnings: usize, max_warnings: Option<usize>) -> i32 {
+    if errors > 0 || max_warnings.is_some_and(|max| warnings > max) {
+        EXIT_FINDINGS
+    } else {
+        EXIT_SUCCESS
+    }
+}
+
+/// Pull the value for a value-taking flag, supporting both `--flag value` and `--flag=value`.
+/// Returns `Err(EXIT_USAGE)` (after printing) when the value is missing.
+fn take_value(
+    arg: &str,
+    flag: &str,
+    args: &mut impl Iterator<Item = String>,
+) -> Result<String, i32> {
+    if let Some(inline) = arg.strip_prefix(&format!("{flag}=")) {
+        return Ok(inline.to_string());
+    }
+    let Some(value) = args.next() else {
+        output::err_line(format!("Missing value for {flag}\n\n{USAGE}"));
+        return Err(EXIT_USAGE);
+    };
+    Ok(value)
+}
+
+/// Parse CLI arguments into `Options`. `Err(code)` means "stop and exit with this code" —
+/// `EXIT_SUCCESS` for `--help`/`--version` (already printed), `EXIT_USAGE` for bad input.
+fn parse_args(mut args: impl Iterator<Item = String>) -> Result<Options, i32> {
+    let mut root: Option<PathBuf> = None;
+    let mut quiet = false;
+    let mut no_summary = false;
+    let mut max_warnings: Option<usize> = None;
+    let mut fail_on = FailLevel::Error;
+    let mut format = OutputFormat::Text;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                output::out_line(USAGE);
+                return Err(EXIT_SUCCESS);
+            }
+            "-V" | "--version" => {
+                output::out_line(format!("locked-in {}", env!("CARGO_PKG_VERSION")));
+                return Err(EXIT_SUCCESS);
+            }
+            "-q" | "--quiet" => quiet = true,
+            "--no-summary" => no_summary = true,
+            _ if arg == "--max-warnings" || arg.starts_with("--max-warnings=") => {
+                let value = take_value(&arg, "--max-warnings", &mut args)?;
+                let Ok(parsed) = value.parse::<usize>() else {
+                    output::err_line(format!("Invalid value for --max-warnings: {value}\n\n{USAGE}"));
+                    return Err(EXIT_USAGE);
+                };
+                max_warnings = Some(parsed);
+            }
+            _ if arg == "--fail-on" || arg.starts_with("--fail-on=") => {
+                let value = take_value(&arg, "--fail-on", &mut args)?;
+                fail_on = match value.as_str() {
+                    "error" => FailLevel::Error,
+                    "warning" => FailLevel::Warning,
+                    _ => {
+                        output::err_line(format!(
+                            "Invalid value for --fail-on: {value} (expected 'error' or 'warning')\n\n{USAGE}"
+                        ));
+                        return Err(EXIT_USAGE);
+                    }
+                };
+            }
+            _ if arg == "--format" || arg.starts_with("--format=") => {
+                let value = take_value(&arg, "--format", &mut args)?;
+                format = match value.as_str() {
+                    "text" => OutputFormat::Text,
+                    "json" => OutputFormat::Json,
+                    _ => {
+                        output::err_line(format!(
+                            "Invalid value for --format: {value} (expected 'text' or 'json')\n\n{USAGE}"
+                        ));
+                        return Err(EXIT_USAGE);
+                    }
+                };
+            }
+            _ if arg.starts_with('-') => {
+                output::err_line(format!("Unknown option: {arg}\n\n{USAGE}"));
+                return Err(EXIT_USAGE);
+            }
+            _ if root.is_some() => {
+                output::err_line(format!("Unexpected extra argument: {arg}\n\n{USAGE}"));
+                return Err(EXIT_USAGE);
+            }
+            _ => root = Some(PathBuf::from(arg)),
+        }
+    }
+
+    Ok(Options {
+        root: root.unwrap_or_else(|| PathBuf::from(".")),
+        quiet,
+        no_summary,
+        max_warnings,
+        fail_on,
+        format,
+    })
+}
 
 pub fn run<I, S>(args: I) -> i32
 where
@@ -11,73 +153,75 @@ where
 {
     let mut args = args.into_iter().map(Into::into);
     let _program = args.next();
-    let mut root: Option<PathBuf> = None;
 
-    for arg in args {
-        match arg.as_str() {
-            "-h" | "--help" => {
-                print!("{USAGE}");
-                return 0;
-            }
-            "-V" | "--version" => {
-                println!("locked-in {}", env!("CARGO_PKG_VERSION"));
-                return 0;
-            }
-            _ if arg.starts_with('-') => {
-                eprintln!("Unknown option: {arg}\n\n{USAGE}");
-                return 2;
-            }
-            _ if root.is_some() => {
-                eprintln!("Unexpected extra argument: {arg}\n\n{USAGE}");
-                return 2;
-            }
-            _ => root = Some(PathBuf::from(arg)),
-        }
+    let options = match parse_args(args) {
+        Ok(options) => options,
+        Err(code) => return code,
+    };
+
+    // Progress chrome goes to stderr so stdout carries only findings.
+    if options.format == OutputFormat::Text {
+        output::err_line("Checking for package manager violations...\n".blue());
     }
 
-    let root = root.unwrap_or_else(|| PathBuf::from("."));
+    let result = lint_files(&options.root);
+    let max = effective_max_warnings(options.max_warnings, options.fail_on);
+    let code = exit_code(result.violations_found, result.warnings_found, max);
 
-    println!("{}", "Checking for package manager violations...\n".blue());
-
-    let result = lint_files(&root);
-
-    println!();
-    println!("{}", "═══════════════════════════════════════".blue());
-
-    if result.violations_found == 0 {
-        println!("{}", "✓ No violations found!".green());
-        if result.warnings_found > 0 {
-            println!(
-                "{}",
-                format!("Warnings: {}", result.warnings_found).yellow()
+    // Buffer findings so large output is a few syscalls, not one per line.
+    let stdout = io::stdout();
+    let mut out = io::BufWriter::new(stdout.lock());
+    match options.format {
+        OutputFormat::Json => {
+            output::guard(render_json(&mut out, &result, options.quiet).and_then(|()| out.flush()));
+        }
+        OutputFormat::Text => {
+            output::guard(
+                render_text(&mut out, &result.results, options.quiet).and_then(|()| out.flush()),
             );
+            if !options.no_summary {
+                print_summary(&result, max);
+            }
         }
-        println!(
-            "{}",
-            format!("Files checked: {}", result.files_checked).blue()
-        );
-        0
-    } else {
-        println!(
-            "{}",
-            format!(
-                "✗ Found {} violation(s) and {} warning(s) in {} files",
-                result.violations_found, result.warnings_found, result.files_checked
-            )
-            .red()
-        );
-        println!(
-            "{}",
-            "Tip: use lockfiles/version pins plus dependency cooldowns (minimum release age) for defense in depth.".blue()
-        );
-        println!();
-        1
     }
+
+    code
+}
+
+fn print_summary(result: &LintResult, max_warnings: Option<usize>) {
+    output::err_line("");
+    output::err_line(DIVIDER.blue());
+
+    if exit_code(result.violations_found, result.warnings_found, max_warnings) == EXIT_SUCCESS {
+        output::err_line("✓ No violations found!".green());
+        if result.warnings_found > 0 {
+            output::err_line(format!("Warnings: {}", result.warnings_found).yellow());
+        }
+        output::err_line(format!("Files checked: {}", result.files_checked).blue());
+        return;
+    }
+
+    let suffix = if result.violations_found == 0 {
+        format!(" (warnings exceed --max-warnings {})", max_warnings.unwrap_or(0))
+    } else {
+        String::new()
+    };
+    output::err_line(
+        format!(
+            "✗ Found {} violation(s) and {} warning(s) in {} files{suffix}",
+            result.violations_found, result.warnings_found, result.files_checked
+        )
+        .red(),
+    );
+    output::err_line(
+        "Tip: use lockfiles/version pins plus dependency cooldowns (minimum release age) for defense in depth.".blue(),
+    );
+    output::err_line("");
 }
 
 #[cfg(test)]
 mod tests {
-    use super::run;
+    use super::{FailLevel, effective_max_warnings, exit_code, run};
 
     #[test]
     fn help_exits_without_scanning() {
@@ -92,5 +236,46 @@ mod tests {
     #[test]
     fn unknown_option_returns_usage_error() {
         assert_eq!(run(["locked-in", "--json"]), 2);
+    }
+
+    #[test]
+    fn invalid_flag_values_return_usage_error() {
+        assert_eq!(run(["locked-in", "--max-warnings", "nope"]), 2);
+        assert_eq!(run(["locked-in", "--max-warnings"]), 2);
+        assert_eq!(run(["locked-in", "--fail-on", "critical"]), 2);
+        assert_eq!(run(["locked-in", "--fail-on"]), 2);
+        assert_eq!(run(["locked-in", "--format", "yaml"]), 2);
+        assert_eq!(run(["locked-in", "--format"]), 2);
+    }
+
+    #[test]
+    fn errors_always_fail_regardless_of_threshold() {
+        assert_eq!(exit_code(1, 0, None), 1);
+        assert_eq!(exit_code(3, 5, Some(10)), 1);
+    }
+
+    #[test]
+    fn warnings_fail_only_above_threshold() {
+        assert_eq!(exit_code(0, 0, None), 0);
+        assert_eq!(exit_code(0, 5, None), 0); // unlimited: warnings never fail
+        assert_eq!(exit_code(0, 0, Some(0)), 0); // zero warnings, threshold 0
+        assert_eq!(exit_code(0, 1, Some(0)), 1); // any warning fails at 0
+        assert_eq!(exit_code(0, 3, Some(3)), 0); // equal to threshold is allowed
+        assert_eq!(exit_code(0, 4, Some(3)), 1); // exceeds threshold
+    }
+
+    #[test]
+    fn fail_on_warning_is_equivalent_to_max_warnings_zero() {
+        assert_eq!(effective_max_warnings(None, FailLevel::Warning), Some(0));
+        assert_eq!(effective_max_warnings(None, FailLevel::Error), None);
+        assert_eq!(effective_max_warnings(Some(5), FailLevel::Error), Some(5));
+    }
+
+    #[test]
+    fn strictest_threshold_wins_when_both_set() {
+        // --fail-on warning (0) is stricter than --max-warnings 5
+        assert_eq!(effective_max_warnings(Some(5), FailLevel::Warning), Some(0));
+        // --max-warnings 0 with --fail-on error stays 0
+        assert_eq!(effective_max_warnings(Some(0), FailLevel::Error), Some(0));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -177,7 +177,7 @@ where
         }
         OutputFormat::Text => {
             output::guard(
-                render_text(&mut out, &result.results, options.quiet).and_then(|()| out.flush()),
+                render_text(&mut out, &result.files, options.quiet).and_then(|()| out.flush()),
             );
             if !options.no_summary {
                 print_summary(&result, max);

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -47,6 +47,7 @@ impl Violation {
 }
 
 pub struct LintResult {
+    pub results: Vec<FileLintResult>,
     pub violations_found: usize,
     pub warnings_found: usize,
     pub files_checked: usize,

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,3 +1,4 @@
+use crate::context::git::GitIndexStatus;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6,48 +7,84 @@ pub enum Severity {
     Warning,
 }
 
-#[derive(Debug)]
-pub struct Violation {
-    pub severity: Severity,
-    pub line_num: usize,
-    pub message: String,
-    pub line_content: String,
-    pub rule_id: Option<String>,
+/// The structured identity of a violation.
+///
+/// The logic layer emits these; `rule_id` and `severity` are derived from the kind, and the
+/// user-facing message is produced separately by the presentation layer (`crate::messages`).
+/// Variants carry any data the message needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ViolationKind {
+    NpmInstallBare,
+    NpmVersionPin,
+    PnpmFrozenLockfile,
+    PnpmVersionPin,
+    YarnFrozenLockfile,
+    YarnVersionPin,
+    BunFrozenLockfile,
+    BunVersionPin,
+    MissingTrackedLockfile { candidates: Vec<String> },
+    GitMetadataUnavailable(GitIndexStatus),
 }
 
-impl Violation {
-    pub fn error(
-        line_num: usize,
-        message: impl Into<String>,
-        line_content: impl Into<String>,
-        rule_id: impl Into<String>,
-    ) -> Self {
-        Self {
-            severity: Severity::Error,
-            line_num,
-            message: message.into(),
-            line_content: line_content.into(),
-            rule_id: Some(rule_id.into()),
+impl ViolationKind {
+    /// Stable identifier used for ignore-directive suppression and JSON output.
+    #[must_use]
+    pub const fn rule_id(&self) -> &'static str {
+        match self {
+            Self::NpmInstallBare => "npm-install-bare",
+            Self::NpmVersionPin => "npm-version-pin",
+            Self::PnpmFrozenLockfile => "pnpm-frozen-lockfile",
+            Self::PnpmVersionPin => "pnpm-version-pin",
+            Self::YarnFrozenLockfile => "yarn-frozen-lockfile",
+            Self::YarnVersionPin => "yarn-version-pin",
+            Self::BunFrozenLockfile => "bun-frozen-lockfile",
+            Self::BunVersionPin => "bun-version-pin",
+            Self::MissingTrackedLockfile { .. } => "missing-tracked-lockfile",
+            Self::GitMetadataUnavailable(_) => "git-metadata-unavailable",
         }
     }
 
-    pub fn warning(
-        message: impl Into<String>,
-        line_content: impl Into<String>,
-        rule_id: impl Into<String>,
-    ) -> Self {
-        Self {
-            severity: Severity::Warning,
-            line_num: 0,
-            message: message.into(),
-            line_content: line_content.into(),
-            rule_id: Some(rule_id.into()),
+    /// Whether this kind fails the run (error) or is informational (warning).
+    #[must_use]
+    pub const fn severity(&self) -> Severity {
+        match self {
+            Self::MissingTrackedLockfile { .. } | Self::GitMetadataUnavailable(_) => {
+                Severity::Warning
+            }
+            _ => Severity::Error,
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct Violation {
+    pub kind: ViolationKind,
+    pub line_num: usize,
+    pub line_content: String,
+}
+
+impl Violation {
+    pub fn new(kind: ViolationKind, line_num: usize, line_content: impl Into<String>) -> Self {
+        Self {
+            kind,
+            line_num,
+            line_content: line_content.into(),
+        }
+    }
+
+    #[must_use]
+    pub const fn severity(&self) -> Severity {
+        self.kind.severity()
+    }
+
+    #[must_use]
+    pub const fn rule_id(&self) -> &'static str {
+        self.kind.rule_id()
     }
 }
 
 pub struct LintResult {
-    pub results: Vec<FileLintResult>,
+    pub files: Vec<FileLintResult>,
     pub violations_found: usize,
     pub warnings_found: usize,
     pub files_checked: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,14 @@ pub mod context;
 mod diagnostic;
 mod file_types;
 mod ignore_directives;
+mod messages;
 mod output;
 mod parsers;
 mod report;
 mod rules;
 mod scanner;
 
-pub use diagnostic::{FileLintResult, LintResult, Severity, Violation};
+pub use diagnostic::{FileLintResult, LintResult, Severity, Violation, ViolationKind};
 pub use scanner::lint_files;
 
 /// Process exit codes. A single source of truth shared across `cli` and `output`.
@@ -40,6 +41,7 @@ mod tests {
     use crate::parsers::line::{
         check_file, is_comment_or_placeholder, should_lint_markdown_code_block,
     };
+    use crate::ViolationKind;
     use crate::rules::{check_bun, check_npm, check_pnpm, check_yarn};
     use std::collections::HashMap;
     use std::fs;
@@ -75,15 +77,14 @@ mod tests {
     fn npm_install_bare_violation() {
         let violations = check_npm("npm install", 1);
         assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].rule_id.as_deref(), Some("npm-install-bare"));
+        assert_eq!(violations[0].kind, ViolationKind::NpmInstallBare);
     }
 
     #[test]
     fn npm_install_global_yarn_is_still_npm() {
         let violations = check_npm("npm install -g yarn", 1);
         assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].rule_id.as_deref(), Some("npm-version-pin"));
-        assert!(violations[0].message.contains("npm"));
+        assert_eq!(violations[0].kind, ViolationKind::NpmVersionPin);
     }
 
     #[test]
@@ -156,7 +157,7 @@ mod tests {
         let content = "# locked-in: ignore[bun-frozen-lockfile]\nbun install\nbun add react\n";
         let violations = check_file(content, &context(false, false, false), &shell_style());
         assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].rule_id.as_deref(), Some("bun-version-pin"));
+        assert_eq!(violations[0].kind, ViolationKind::BunVersionPin);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod context;
 mod diagnostic;
 mod file_types;
 mod ignore_directives;
+mod output;
 mod parsers;
 mod report;
 mod rules;
@@ -10,6 +11,17 @@ mod scanner;
 
 pub use diagnostic::{FileLintResult, LintResult, Severity, Violation};
 pub use scanner::lint_files;
+
+/// Process exit codes. A single source of truth shared across `cli` and `output`.
+pub const EXIT_SUCCESS: i32 = 0;
+pub const EXIT_FINDINGS: i32 = 1;
+pub const EXIT_USAGE: i32 = 2;
+/// Conventional "killed by SIGPIPE" code (128 + 13). Rust ignores SIGPIPE, so we map a
+/// broken pipe to this ourselves rather than exiting `0` (which would mask findings).
+pub const EXIT_BROKEN_PIPE: i32 = 141;
+/// A write to stdout/stderr failed for a reason other than a broken pipe (e.g. a full
+/// disk on a redirect). Surfaced loudly rather than producing truncated output silently.
+pub const EXIT_IO_ERROR: i32 = 74;
 
 #[cfg(test)]
 mod tests {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,0 +1,116 @@
+use crate::context::git::GitIndexStatus;
+use crate::{Severity, ViolationKind};
+
+/// The human-readable message for a violation. This is the presentation layer's job — the
+/// logic layer (`rules`, `scanner`) only emits structured `ViolationKind`s.
+pub fn violation_message(kind: &ViolationKind) -> String {
+    match kind {
+        ViolationKind::NpmInstallBare => {
+            "Use 'npm ci' instead of 'npm install' for lockfile-based installations".to_string()
+        }
+        ViolationKind::NpmVersionPin => {
+            "npm package installation without version pin (use 'npm i package@version')".to_string()
+        }
+        ViolationKind::PnpmFrozenLockfile => {
+            "Use 'pnpm install --frozen-lockfile' to respect lockfile".to_string()
+        }
+        ViolationKind::PnpmVersionPin => {
+            "pnpm package installation without version pin (use 'pnpm add package@version')"
+                .to_string()
+        }
+        ViolationKind::YarnFrozenLockfile => {
+            "Use 'yarn install --frozen-lockfile' to respect lockfile".to_string()
+        }
+        ViolationKind::YarnVersionPin => {
+            "yarn package installation without version pin (use 'yarn add package@version')"
+                .to_string()
+        }
+        ViolationKind::BunFrozenLockfile => {
+            "Use 'bun install --frozen-lockfile' unless repo-local bunfig.toml sets '[install].frozenLockfile = true' (https://bun.com/docs/runtime/bunfig#install-frozenlockfile)"
+                .to_string()
+        }
+        ViolationKind::BunVersionPin => {
+            "bun package installation without version pin (use 'bun add package@version')"
+                .to_string()
+        }
+        ViolationKind::MissingTrackedLockfile { candidates } => {
+            format!(
+                "Tracked manifest is missing a tracked lockfile: {}",
+                candidates.join(", ")
+            )
+        }
+        ViolationKind::GitMetadataUnavailable(status) => match status {
+            GitIndexStatus::MissingMetadata => {
+                "Git metadata not found; skipping tracked lockfile validation".to_string()
+            }
+            GitIndexStatus::MissingIndex => {
+                "Git index not found; skipping tracked lockfile validation".to_string()
+            }
+            GitIndexStatus::UnsupportedIndex => {
+                "Git index could not be parsed; skipping tracked lockfile validation".to_string()
+            }
+        },
+    }
+}
+
+/// Human-facing severity label used in text output.
+pub const fn severity_label(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "Error",
+        Severity::Warning => "Warning",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{severity_label, violation_message};
+    use crate::context::git::GitIndexStatus;
+    use crate::{Severity, ViolationKind};
+
+    #[test]
+    fn static_kind_message_is_exact() {
+        assert_eq!(
+            violation_message(&ViolationKind::NpmInstallBare),
+            "Use 'npm ci' instead of 'npm install' for lockfile-based installations"
+        );
+    }
+
+    #[test]
+    fn missing_lockfile_joins_candidates() {
+        let kind = ViolationKind::MissingTrackedLockfile {
+            candidates: vec!["a/package-lock.json".to_string(), "a/yarn.lock".to_string()],
+        };
+        assert_eq!(
+            violation_message(&kind),
+            "Tracked manifest is missing a tracked lockfile: a/package-lock.json, a/yarn.lock"
+        );
+    }
+
+    #[test]
+    fn git_status_variants_each_have_a_message() {
+        assert_eq!(
+            violation_message(&ViolationKind::GitMetadataUnavailable(
+                GitIndexStatus::MissingMetadata
+            )),
+            "Git metadata not found; skipping tracked lockfile validation"
+        );
+        assert_eq!(
+            violation_message(&ViolationKind::GitMetadataUnavailable(
+                GitIndexStatus::MissingIndex
+            )),
+            "Git index not found; skipping tracked lockfile validation"
+        );
+        assert_eq!(
+            violation_message(&ViolationKind::GitMetadataUnavailable(
+                GitIndexStatus::UnsupportedIndex
+            )),
+            "Git index could not be parsed; skipping tracked lockfile validation"
+        );
+    }
+
+    #[test]
+    fn labels_match_severity() {
+        assert_eq!(severity_label(Severity::Error), "Error");
+        assert_eq!(severity_label(Severity::Warning), "Warning");
+    }
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,33 @@
+use crate::{EXIT_BROKEN_PIPE, EXIT_IO_ERROR};
+use std::fmt::Display;
+use std::io::{self, Write};
+
+/// Resolve a write result into a clean process exit when the stream has failed.
+///
+/// Rust's `print!`/`writeln!` panic on `EPIPE`; routing writes through here lets
+/// `locked-in . | head` terminate cleanly (exit `141`). This is the *only* place output
+/// code may end the process — leaf renderers return `io::Result` and stay side-effect-free.
+/// A broken pipe is an expected, clean end of output. Any *other* write error (e.g. a full
+/// disk on a redirect) is surfaced loudly — a message plus a non-zero exit — rather than
+/// leaving truncated output behind while reporting success.
+pub fn guard(result: io::Result<()>) {
+    let Err(e) = result else { return };
+    if e.kind() == io::ErrorKind::BrokenPipe {
+        std::process::exit(EXIT_BROKEN_PIPE);
+    }
+    // Best-effort diagnostic; the stream we'd report on may itself be the one that failed.
+    let _ = writeln!(io::stderr(), "locked-in: error writing output: {e}");
+    std::process::exit(EXIT_IO_ERROR);
+}
+
+/// Write a single line to stdout, broken-pipe-safe.
+pub fn out_line(text: impl Display) {
+    let stdout = io::stdout();
+    guard(writeln!(stdout.lock(), "{text}"));
+}
+
+/// Write a single line to stderr, broken-pipe-safe.
+pub fn err_line(text: impl Display) {
+    let stderr = io::stderr();
+    guard(writeln!(stderr.lock(), "{text}"));
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -20,13 +20,11 @@ pub fn guard(result: io::Result<()>) {
     std::process::exit(EXIT_IO_ERROR);
 }
 
-/// Write a single line to stdout, broken-pipe-safe.
 pub fn out_line(text: impl Display) {
     let stdout = io::stdout();
     guard(writeln!(stdout.lock(), "{text}"));
 }
 
-/// Write a single line to stderr, broken-pipe-safe.
 pub fn err_line(text: impl Display) {
     let stderr = io::stderr();
     guard(writeln!(stderr.lock(), "{text}"));

--- a/src/parsers/line.rs
+++ b/src/parsers/line.rs
@@ -72,10 +72,10 @@ pub fn check_file(
         let mut line_violations = rules.check(effective_line, line_num, lint_context);
 
         if let Some(IgnoreDirective::Specific(rule)) = &prev_skip {
-            line_violations.retain(|v| v.rule_id.as_deref() != Some(rule.as_str()));
+            line_violations.retain(|v| v.rule_id() != rule.as_str());
         }
         if let Some(IgnoreDirective::Specific(rule)) = &inline_skip {
-            line_violations.retain(|v| v.rule_id.as_deref() != Some(rule.as_str()));
+            line_violations.retain(|v| v.rule_id() != rule.as_str());
         }
 
         violations.extend(line_violations);

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,34 +1,204 @@
-use crate::{Severity, Violation};
+use crate::{FileLintResult, LintResult, Severity, Violation};
 use colored::Colorize;
-use std::path::Path;
+use serde_json::{Value, json};
+use std::io::{self, Write};
 
-pub fn print_violations(path: &Path, violations: &[Violation]) {
-    let has_errors = violations
+/// Version of the `--format json` document shape; bump on any breaking schema change.
+const JSON_SCHEMA_VERSION: u32 = 1;
+
+/// Violations to display for one file: all of them, or errors-only under `--quiet`.
+fn displayed_violations(violations: &[Violation], quiet: bool) -> Vec<&Violation> {
+    violations
         .iter()
-        .any(|violation| violation.severity == Severity::Error);
-    let heading = if has_errors {
-        format!("✗ {}", path.display()).red()
-    } else {
-        format!("! {}", path.display()).yellow()
-    };
+        .filter(|violation| !quiet || violation.severity == Severity::Error)
+        .collect()
+}
 
-    println!("{heading}");
-    for violation in violations {
-        let label = match violation.severity {
-            Severity::Error => "Error",
-            Severity::Warning => "Warning",
-        };
-        let location = if violation.line_num == 0 {
-            label.to_string()
-        } else {
-            format!("{label} line {}", violation.line_num)
-        };
-        println!(
-            "  {} {}",
-            format!("{location}:").yellow(),
-            violation.message
-        );
-        println!("  {} {}", ">".blue(), violation.line_content);
+/// Human-facing label (text format).
+const fn severity_label(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "Error",
+        Severity::Warning => "Warning",
     }
-    println!();
+}
+
+/// Stable wire value (JSON format) — intentionally independent of the display label.
+const fn severity_json(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+    }
+}
+
+/// Render findings as human-readable text. Files with nothing left to show (e.g. a
+/// warning-only file under `--quiet`) are skipped entirely.
+pub fn render_text(w: &mut dyn Write, results: &[FileLintResult], quiet: bool) -> io::Result<()> {
+    for file in results {
+        let displayed = displayed_violations(&file.violations, quiet);
+        if displayed.is_empty() {
+            continue;
+        }
+
+        let has_errors = displayed
+            .iter()
+            .any(|violation| violation.severity == Severity::Error);
+        if has_errors {
+            writeln!(w, "{}", format!("✗ {}", file.path.display()).red())?;
+        } else {
+            writeln!(w, "{}", format!("! {}", file.path.display()).yellow())?;
+        }
+
+        for violation in displayed {
+            let label = severity_label(violation.severity);
+            let location = if violation.line_num == 0 {
+                label.to_string()
+            } else {
+                format!("{label} line {}", violation.line_num)
+            };
+            writeln!(
+                w,
+                "  {} {}",
+                format!("{location}:").yellow(),
+                violation.message
+            )?;
+            writeln!(w, "  {} {}", ">".blue(), violation.line_content)?;
+        }
+        writeln!(w)?;
+    }
+    Ok(())
+}
+
+/// Render findings as a single JSON document. Counts always reflect the full scan;
+/// `--quiet` filters warnings out of the per-file arrays for consistency with text.
+/// Note: `files` lists only files with displayed findings, so `files.len()` is not
+/// necessarily `files_checked`.
+pub fn render_json(w: &mut dyn Write, result: &LintResult, quiet: bool) -> io::Result<()> {
+    let files: Vec<Value> = result
+        .results
+        .iter()
+        .filter_map(|file| {
+            let displayed = displayed_violations(&file.violations, quiet);
+            if displayed.is_empty() {
+                return None;
+            }
+            let violations: Vec<Value> = displayed
+                .iter()
+                .map(|violation| {
+                    let mut obj = serde_json::Map::new();
+                    obj.insert(
+                        "severity".to_string(),
+                        json!(severity_json(violation.severity)),
+                    );
+                    obj.insert("rule_id".to_string(), json!(violation.rule_id));
+                    if violation.line_num != 0 {
+                        obj.insert("line".to_string(), json!(violation.line_num));
+                    }
+                    obj.insert("message".to_string(), json!(violation.message));
+                    obj.insert("line_content".to_string(), json!(violation.line_content));
+                    Value::Object(obj)
+                })
+                .collect();
+            Some(json!({
+                "path": file.path.display().to_string(),
+                "violations": violations,
+            }))
+        })
+        .collect();
+
+    let doc = json!({
+        "schema_version": JSON_SCHEMA_VERSION,
+        "files_checked": result.files_checked,
+        "violations_found": result.violations_found,
+        "warnings_found": result.warnings_found,
+        "files": files,
+    });
+
+    serde_json::to_string_pretty(&doc).map_or(Ok(()), |text| writeln!(w, "{text}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{render_json, render_text};
+    use crate::{FileLintResult, LintResult, Violation};
+    use std::path::PathBuf;
+
+    fn sample() -> LintResult {
+        let results = vec![FileLintResult {
+            path: PathBuf::from("Dockerfile"),
+            violations: vec![
+                Violation::error(2, "use npm ci", "RUN npm install", "npm-install-bare"),
+                Violation::warning("missing lockfile", "package.json", "missing-tracked-lockfile"),
+            ],
+        }];
+        LintResult {
+            results,
+            violations_found: 1,
+            warnings_found: 1,
+            files_checked: 1,
+        }
+    }
+
+    fn text(quiet: bool) -> String {
+        let mut buf = Vec::new();
+        render_text(&mut buf, &sample().results, quiet).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn json_doc(quiet: bool) -> serde_json::Value {
+        let mut buf = Vec::new();
+        render_json(&mut buf, &sample(), quiet).unwrap();
+        serde_json::from_slice(&buf).unwrap()
+    }
+
+    #[test]
+    fn text_shows_errors_and_warnings() {
+        let out = text(false);
+        assert!(out.contains("Error line 2:"));
+        assert!(out.contains("Warning:"));
+        assert!(out.contains("use npm ci"));
+    }
+
+    #[test]
+    fn text_quiet_drops_warning_lines() {
+        let out = text(true);
+        assert!(out.contains("Error line 2:"));
+        assert!(!out.contains("Warning:"), "warnings suppressed: {out}");
+    }
+
+    #[test]
+    fn json_has_counts_and_per_file_violations() {
+        let doc = json_doc(false);
+
+        assert_eq!(doc["schema_version"], 1);
+        assert_eq!(doc["violations_found"], 1);
+        assert_eq!(doc["warnings_found"], 1);
+        assert_eq!(doc["files"][0]["path"], "Dockerfile");
+        let first = &doc["files"][0]["violations"][0];
+        assert_eq!(first["severity"], "error");
+        assert_eq!(first["line"], 2);
+        assert_eq!(first["rule_id"], "npm-install-bare");
+    }
+
+    #[test]
+    fn json_quiet_filters_warnings_but_keeps_counts() {
+        let doc = json_doc(true);
+
+        assert_eq!(doc["warnings_found"], 1, "count reflects full scan");
+        let severities: Vec<&str> = doc["files"][0]["violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["severity"].as_str().unwrap())
+            .collect();
+        assert_eq!(severities, ["error"], "warnings filtered from arrays");
+    }
+
+    #[test]
+    fn json_omits_line_for_file_level_warnings() {
+        let doc = json_doc(false);
+        // The warning (line_num 0) must not carry a "line" key.
+        let warning = &doc["files"][0]["violations"][1];
+        assert_eq!(warning["severity"], "warning");
+        assert!(warning.get("line").is_none(), "no line for file-level warning");
+    }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,3 +1,4 @@
+use crate::messages::{severity_label, violation_message};
 use crate::{FileLintResult, LintResult, Severity, Violation};
 use colored::Colorize;
 use serde_json::{Value, json};
@@ -10,16 +11,8 @@ const JSON_SCHEMA_VERSION: u32 = 1;
 fn displayed_violations(violations: &[Violation], quiet: bool) -> Vec<&Violation> {
     violations
         .iter()
-        .filter(|violation| !quiet || violation.severity == Severity::Error)
+        .filter(|violation| !quiet || violation.severity() == Severity::Error)
         .collect()
-}
-
-/// Human-facing label (text format).
-const fn severity_label(severity: Severity) -> &'static str {
-    match severity {
-        Severity::Error => "Error",
-        Severity::Warning => "Warning",
-    }
 }
 
 /// Stable wire value (JSON format) — intentionally independent of the display label.
@@ -32,8 +25,8 @@ const fn severity_json(severity: Severity) -> &'static str {
 
 /// Render findings as human-readable text. Files with nothing left to show (e.g. a
 /// warning-only file under `--quiet`) are skipped entirely.
-pub fn render_text(w: &mut dyn Write, results: &[FileLintResult], quiet: bool) -> io::Result<()> {
-    for file in results {
+pub fn render_text(w: &mut dyn Write, files: &[FileLintResult], quiet: bool) -> io::Result<()> {
+    for file in files {
         let displayed = displayed_violations(&file.violations, quiet);
         if displayed.is_empty() {
             continue;
@@ -41,7 +34,7 @@ pub fn render_text(w: &mut dyn Write, results: &[FileLintResult], quiet: bool) -
 
         let has_errors = displayed
             .iter()
-            .any(|violation| violation.severity == Severity::Error);
+            .any(|violation| violation.severity() == Severity::Error);
         if has_errors {
             writeln!(w, "{}", format!("✗ {}", file.path.display()).red())?;
         } else {
@@ -49,7 +42,7 @@ pub fn render_text(w: &mut dyn Write, results: &[FileLintResult], quiet: bool) -
         }
 
         for violation in displayed {
-            let label = severity_label(violation.severity);
+            let label = severity_label(violation.severity());
             let location = if violation.line_num == 0 {
                 label.to_string()
             } else {
@@ -59,7 +52,7 @@ pub fn render_text(w: &mut dyn Write, results: &[FileLintResult], quiet: bool) -
                 w,
                 "  {} {}",
                 format!("{location}:").yellow(),
-                violation.message
+                violation_message(&violation.kind)
             )?;
             writeln!(w, "  {} {}", ">".blue(), violation.line_content)?;
         }
@@ -74,7 +67,7 @@ pub fn render_text(w: &mut dyn Write, results: &[FileLintResult], quiet: bool) -
 /// necessarily `files_checked`.
 pub fn render_json(w: &mut dyn Write, result: &LintResult, quiet: bool) -> io::Result<()> {
     let files: Vec<Value> = result
-        .results
+        .files
         .iter()
         .filter_map(|file| {
             let displayed = displayed_violations(&file.violations, quiet);
@@ -87,13 +80,13 @@ pub fn render_json(w: &mut dyn Write, result: &LintResult, quiet: bool) -> io::R
                     let mut obj = serde_json::Map::new();
                     obj.insert(
                         "severity".to_string(),
-                        json!(severity_json(violation.severity)),
+                        json!(severity_json(violation.severity())),
                     );
-                    obj.insert("rule_id".to_string(), json!(violation.rule_id));
+                    obj.insert("rule_id".to_string(), json!(violation.rule_id()));
                     if violation.line_num != 0 {
                         obj.insert("line".to_string(), json!(violation.line_num));
                     }
-                    obj.insert("message".to_string(), json!(violation.message));
+                    obj.insert("message".to_string(), json!(violation_message(&violation.kind)));
                     obj.insert("line_content".to_string(), json!(violation.line_content));
                     Value::Object(obj)
                 })
@@ -119,19 +112,25 @@ pub fn render_json(w: &mut dyn Write, result: &LintResult, quiet: bool) -> io::R
 #[cfg(test)]
 mod tests {
     use super::{render_json, render_text};
-    use crate::{FileLintResult, LintResult, Violation};
+    use crate::{FileLintResult, LintResult, Violation, ViolationKind};
     use std::path::PathBuf;
 
     fn sample() -> LintResult {
-        let results = vec![FileLintResult {
+        let files = vec![FileLintResult {
             path: PathBuf::from("Dockerfile"),
             violations: vec![
-                Violation::error(2, "use npm ci", "RUN npm install", "npm-install-bare"),
-                Violation::warning("missing lockfile", "package.json", "missing-tracked-lockfile"),
+                Violation::new(ViolationKind::NpmInstallBare, 2, "RUN npm install"),
+                Violation::new(
+                    ViolationKind::MissingTrackedLockfile {
+                        candidates: vec!["package-lock.json".to_string()],
+                    },
+                    0,
+                    "package.json",
+                ),
             ],
         }];
         LintResult {
-            results,
+            files,
             violations_found: 1,
             warnings_found: 1,
             files_checked: 1,
@@ -140,7 +139,7 @@ mod tests {
 
     fn text(quiet: bool) -> String {
         let mut buf = Vec::new();
-        render_text(&mut buf, &sample().results, quiet).unwrap();
+        render_text(&mut buf, &sample().files, quiet).unwrap();
         String::from_utf8(buf).unwrap()
     }
 
@@ -155,7 +154,7 @@ mod tests {
         let out = text(false);
         assert!(out.contains("Error line 2:"));
         assert!(out.contains("Warning:"));
-        assert!(out.contains("use npm ci"));
+        assert!(out.contains("Use 'npm ci'"));
     }
 
     #[test]

--- a/src/rules/bun.rs
+++ b/src/rules/bun.rs
@@ -1,4 +1,4 @@
-use crate::Violation;
+use crate::{Violation, ViolationKind};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -13,20 +13,18 @@ pub fn check_bun(line: &str, line_num: usize, bun_frozen_lockfile: bool) -> Vec<
 
     if BUN_INSTALL_RE.is_match(line) && !line.contains("--frozen-lockfile") && !bun_frozen_lockfile
     {
-        violations.push(Violation::error(
+        violations.push(Violation::new(
+            ViolationKind::BunFrozenLockfile,
             line_num,
-            "Use 'bun install --frozen-lockfile' unless repo-local bunfig.toml sets '[install].frozenLockfile = true' (https://bun.com/docs/runtime/bunfig#install-frozenlockfile)",
             line.trim(),
-            "bun-frozen-lockfile",
         ));
     }
 
     if BUN_ADD_RE.is_match(line) && !has_version_pin(line) {
-        violations.push(Violation::error(
+        violations.push(Violation::new(
+            ViolationKind::BunVersionPin,
             line_num,
-            "bun package installation without version pin (use 'bun add package@version')",
             line.trim(),
-            "bun-version-pin",
         ));
     }
 

--- a/src/rules/npm.rs
+++ b/src/rules/npm.rs
@@ -1,4 +1,4 @@
-use crate::Violation;
+use crate::{Violation, ViolationKind};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -22,18 +22,16 @@ pub fn check_npm(line: &str, line_num: usize) -> Vec<Violation> {
         }
 
         if BARE_NPM_INSTALL_RE.is_match(line) {
-            violations.push(Violation::error(
+            violations.push(Violation::new(
+                ViolationKind::NpmInstallBare,
                 line_num,
-                "Use 'npm ci' instead of 'npm install' for lockfile-based installations",
                 line.trim(),
-                "npm-install-bare",
             ));
         } else {
-            violations.push(Violation::error(
+            violations.push(Violation::new(
+                ViolationKind::NpmVersionPin,
                 line_num,
-                "npm package installation without version pin (use 'npm i package@version')",
                 line.trim(),
-                "npm-version-pin",
             ));
         }
     }

--- a/src/rules/pnpm.rs
+++ b/src/rules/pnpm.rs
@@ -1,4 +1,4 @@
-use crate::Violation;
+use crate::{Violation, ViolationKind};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -12,20 +12,18 @@ pub fn check_pnpm(line: &str, line_num: usize) -> Vec<Violation> {
     let mut violations = Vec::new();
 
     if PNPM_INSTALL_RE.is_match(line) && !line.contains("--frozen-lockfile") {
-        violations.push(Violation::error(
+        violations.push(Violation::new(
+            ViolationKind::PnpmFrozenLockfile,
             line_num,
-            "Use 'pnpm install --frozen-lockfile' to respect lockfile",
             line.trim(),
-            "pnpm-frozen-lockfile",
         ));
     }
 
     if PNPM_ADD_RE.is_match(line) && !has_version_pin(line) {
-        violations.push(Violation::error(
+        violations.push(Violation::new(
+            ViolationKind::PnpmVersionPin,
             line_num,
-            "pnpm package installation without version pin (use 'pnpm add package@version')",
             line.trim(),
-            "pnpm-version-pin",
         ));
     }
 

--- a/src/rules/yarn.rs
+++ b/src/rules/yarn.rs
@@ -1,4 +1,4 @@
-use crate::Violation;
+use crate::{Violation, ViolationKind};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -15,20 +15,18 @@ pub fn check_yarn(line: &str, line_num: usize) -> Vec<Violation> {
     let mut violations = Vec::new();
 
     if YARN_INSTALL_RE.is_match(line) && !YARN_FROZEN_RE.is_match(line) {
-        violations.push(Violation::error(
+        violations.push(Violation::new(
+            ViolationKind::YarnFrozenLockfile,
             line_num,
-            "Use 'yarn install --frozen-lockfile' to respect lockfile",
             line.trim(),
-            "yarn-frozen-lockfile",
         ));
     }
 
     if YARN_ADD_RE.is_match(line) && !has_version_pin(line) {
-        violations.push(Violation::error(
+        violations.push(Violation::new(
+            ViolationKind::YarnVersionPin,
             line_num,
-            "yarn package installation without version pin (use 'yarn add package@version')",
             line.trim(),
-            "yarn-version-pin",
         ));
     }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -8,7 +8,6 @@ use crate::file_types::{
     comment_style_for_file, has_extension, is_excluded, is_package_json, should_check_file,
 };
 use crate::parsers::line::check_file;
-use crate::report::print_violations;
 use ignore::WalkBuilder;
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
@@ -55,29 +54,27 @@ pub fn lint_files(root: &Path) -> LintResult {
     let mut warnings_found: usize = 0;
 
     for result in &checked_results {
-        if !result.violations.is_empty() {
-            print_violations(&result.path, &result.violations);
-            violations_found = violations_found.saturating_add(
-                result
-                    .violations
-                    .iter()
-                    .filter(|violation| violation.severity == Severity::Error)
-                    .count(),
-            );
-            warnings_found = warnings_found.saturating_add(
-                result
-                    .violations
-                    .iter()
-                    .filter(|violation| violation.severity == Severity::Warning)
-                    .count(),
-            );
-        }
+        violations_found = violations_found.saturating_add(
+            result
+                .violations
+                .iter()
+                .filter(|violation| violation.severity == Severity::Error)
+                .count(),
+        );
+        warnings_found = warnings_found.saturating_add(
+            result
+                .violations
+                .iter()
+                .filter(|violation| violation.severity == Severity::Warning)
+                .count(),
+        );
     }
 
     LintResult {
+        files_checked: checked_results.len(),
+        results: checked_results,
         violations_found,
         warnings_found,
-        files_checked: checked_results.len(),
     }
 }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -3,7 +3,7 @@ use crate::context::git::{GitIndexStatus, SubmodulePruner, tracked_paths};
 use crate::context::lockfiles::{
     Ecosystem, expected_lockfile_paths, expected_lockfiles_for_manifest,
 };
-use crate::diagnostic::{FileLintResult, LintResult, Severity, Violation};
+use crate::diagnostic::{FileLintResult, LintResult, Severity, Violation, ViolationKind};
 use crate::file_types::{
     comment_style_for_file, has_extension, is_excluded, is_package_json, should_check_file,
 };
@@ -58,21 +58,21 @@ pub fn lint_files(root: &Path) -> LintResult {
             result
                 .violations
                 .iter()
-                .filter(|violation| violation.severity == Severity::Error)
+                .filter(|violation| violation.severity() == Severity::Error)
                 .count(),
         );
         warnings_found = warnings_found.saturating_add(
             result
                 .violations
                 .iter()
-                .filter(|violation| violation.severity == Severity::Warning)
+                .filter(|violation| violation.severity() == Severity::Warning)
                 .count(),
         );
     }
 
     LintResult {
         files_checked: checked_results.len(),
-        results: checked_results,
+        files: checked_results,
         violations_found,
         warnings_found,
     }
@@ -131,17 +131,16 @@ fn check_tracked_lockfiles(root: &Path) -> Vec<FileLintResult> {
             continue;
         }
 
-        let lockfiles = acceptable_paths
+        let candidates = acceptable_paths
             .iter()
-            .map(|path| path.to_string_lossy())
-            .collect::<Vec<_>>()
-            .join(", ");
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
         results.push(FileLintResult {
             path: root.join(&manifest),
-            violations: vec![Violation::warning(
-                format!("Tracked manifest is missing a tracked lockfile: {lockfiles}"),
+            violations: vec![Violation::new(
+                ViolationKind::MissingTrackedLockfile { candidates },
+                0,
                 manifest.to_string_lossy(),
-                "missing-tracked-lockfile",
             )],
         });
     }
@@ -219,15 +218,9 @@ fn cargo_manifest_is_workspace(root: &Path, manifest: &Path) -> bool {
 }
 
 fn git_metadata_warning(status: GitIndexStatus) -> Violation {
-    let message = match status {
-        GitIndexStatus::MissingMetadata => {
-            "Git metadata not found; skipping tracked lockfile validation"
-        }
-        GitIndexStatus::MissingIndex => "Git index not found; skipping tracked lockfile validation",
-        GitIndexStatus::UnsupportedIndex => {
-            "Git index could not be parsed; skipping tracked lockfile validation"
-        }
-    };
-
-    Violation::warning(message, ".git/index", "git-metadata-unavailable")
+    Violation::new(
+        ViolationKind::GitMetadataUnavailable(status),
+        0,
+        ".git/index",
+    )
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,259 @@
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Distinctive substring from a `git-metadata-unavailable` warning line (`src/scanner.rs`).
+const WARNING_MARKER: &str = "Git metadata not found";
+
+fn temp_dir(name: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("locked-in-it-{name}-{nonce}"));
+    fs::create_dir(&path).unwrap();
+    path
+}
+
+/// A repo with exactly one error (bare `npm install` in a Dockerfile) and one warning
+/// (no `.git`, so tracked-lockfile validation is skipped with a warning).
+fn fixture_error_and_warning(name: &str) -> PathBuf {
+    let root = temp_dir(name);
+    fs::write(root.join("Dockerfile"), "FROM node:20\nRUN npm install\n").unwrap();
+    root
+}
+
+/// A repo with zero errors and exactly one warning (empty dir, no `.git`).
+fn fixture_warning_only(name: &str) -> PathBuf {
+    temp_dir(name)
+}
+
+struct Output {
+    stdout: String,
+    stderr: String,
+    code: i32,
+}
+
+fn run(root: &PathBuf, args: &[&str]) -> Output {
+    let output = Command::new(env!("CARGO_BIN_EXE_locked-in"))
+        .args(args)
+        .arg(root)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run locked-in binary");
+    Output {
+        stdout: String::from_utf8(output.stdout).expect("stdout was not valid utf-8"),
+        stderr: String::from_utf8(output.stderr).expect("stderr was not valid utf-8"),
+        code: output.status.code().expect("process had no exit code"),
+    }
+}
+
+#[test]
+fn findings_go_to_stdout_chrome_goes_to_stderr() {
+    let root = fixture_error_and_warning("streams");
+    let out = run(&root, &[]);
+    fs::remove_dir_all(&root).unwrap();
+
+    // Findings on stdout.
+    assert!(out.stdout.contains("Error"), "error finding on stdout: {}", out.stdout);
+    assert!(
+        out.stdout.contains(WARNING_MARKER),
+        "warning finding on stdout: {}",
+        out.stdout
+    );
+    // Progress + summary chrome on stderr, not stdout.
+    assert!(
+        out.stderr.contains("Checking for package manager violations"),
+        "progress line on stderr: {}",
+        out.stderr
+    );
+    assert!(out.stderr.contains("violation(s)"), "summary on stderr: {}", out.stderr);
+    assert!(!out.stdout.contains("violation(s)"), "summary not on stdout: {}", out.stdout);
+    assert_eq!(out.code, 1, "errors must fail");
+}
+
+#[test]
+fn quiet_suppresses_warning_findings_but_keeps_errors() {
+    let root = fixture_error_and_warning("quiet");
+    let out = run(&root, &["--quiet"]);
+    fs::remove_dir_all(&root).unwrap();
+
+    assert!(out.stdout.contains("Error"), "errors must still print: {}", out.stdout);
+    assert!(
+        !out.stdout.contains(WARNING_MARKER),
+        "warning findings must be suppressed: {}",
+        out.stdout
+    );
+    assert!(out.stderr.contains("violation(s)"), "summary still on stderr: {}", out.stderr);
+    assert_eq!(out.code, 1, "exit code unchanged by --quiet");
+}
+
+#[test]
+fn max_warnings_zero_fails_on_a_warning_with_no_errors() {
+    let root = fixture_warning_only("max-warnings");
+    let out = run(&root, &["--max-warnings", "0"]);
+    fs::remove_dir_all(&root).unwrap();
+
+    assert_eq!(out.code, 1, "any warning must fail at --max-warnings 0");
+}
+
+#[test]
+fn warnings_do_not_fail_by_default() {
+    let root = fixture_warning_only("default-warning");
+    let out = run(&root, &[]);
+    fs::remove_dir_all(&root).unwrap();
+
+    assert_eq!(out.code, 0, "warnings alone must not fail with no flags");
+}
+
+#[test]
+fn fail_on_warning_matches_max_warnings_zero() {
+    let root_a = fixture_warning_only("fail-on-a");
+    let a = run(&root_a, &["--fail-on", "warning"]);
+    fs::remove_dir_all(&root_a).unwrap();
+
+    let root_b = fixture_warning_only("fail-on-b");
+    let b = run(&root_b, &["--max-warnings", "0"]);
+    fs::remove_dir_all(&root_b).unwrap();
+
+    assert_eq!(a.code, 1);
+    assert_eq!(a.code, b.code, "--fail-on warning must alias --max-warnings 0");
+}
+
+#[test]
+fn no_summary_omits_trailing_block_but_keeps_progress_line() {
+    let root = fixture_error_and_warning("no-summary");
+    let out = run(&root, &["--no-summary"]);
+    fs::remove_dir_all(&root).unwrap();
+
+    assert!(
+        out.stderr.contains("Checking for package manager violations"),
+        "progress line must remain on stderr: {}",
+        out.stderr
+    );
+    assert!(!out.stderr.contains("═══"), "summary divider must be gone: {}", out.stderr);
+    assert!(
+        !out.stderr.contains("violation(s)"),
+        "summary block must be gone: {}",
+        out.stderr
+    );
+    assert_eq!(out.code, 1, "exit code unaffected by --no-summary");
+}
+
+#[test]
+fn quiet_and_max_warnings_compose() {
+    let root = fixture_error_and_warning("compose");
+    let out = run(&root, &["--quiet", "--max-warnings", "0"]);
+    fs::remove_dir_all(&root).unwrap();
+
+    assert!(out.stdout.contains("Error"), "errors must print: {}", out.stdout);
+    assert!(
+        !out.stdout.contains(WARNING_MARKER),
+        "warnings must be suppressed under --quiet: {}",
+        out.stdout
+    );
+    assert_eq!(out.code, 1, "exit 1 from the error (and the warning threshold)");
+}
+
+#[test]
+fn json_format_emits_parseable_document_with_counts() {
+    let root = fixture_error_and_warning("json");
+    let out = run(&root, &["--format", "json"]);
+    fs::remove_dir_all(&root).unwrap();
+
+    // stdout must be pure JSON (no chrome).
+    assert!(!out.stdout.contains("Checking"), "no chrome on stdout: {}", out.stdout);
+    let doc: serde_json::Value =
+        serde_json::from_str(&out.stdout).expect("stdout must be valid JSON");
+    assert_eq!(doc["violations_found"], 1);
+    assert_eq!(doc["warnings_found"], 1);
+    assert!(doc["files"].as_array().is_some_and(|f| !f.is_empty()));
+    assert_eq!(out.code, 1);
+}
+
+#[test]
+fn quiet_json_drops_warnings_but_keeps_counts() {
+    let root = fixture_error_and_warning("json-quiet");
+    let out = run(&root, &["--format", "json", "--quiet"]);
+    fs::remove_dir_all(&root).unwrap();
+
+    let doc: serde_json::Value =
+        serde_json::from_str(&out.stdout).expect("stdout must be valid JSON");
+    // Counts always reflect the full scan.
+    assert_eq!(doc["warnings_found"], 1);
+    // But no warning severities appear in the per-file arrays.
+    let severities: Vec<String> = doc["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|f| f["violations"].as_array().unwrap())
+        .map(|v| v["severity"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        severities.iter().all(|s| s == "error"),
+        "only errors under --quiet: {severities:?}"
+    );
+}
+
+#[test]
+fn help_text_goes_to_stdout() {
+    let root = fixture_warning_only("help-stream");
+    let out = run(&root, &["--help"]);
+    fs::remove_dir_all(&root).unwrap();
+
+    assert!(out.stdout.contains("Usage: locked-in"), "help on stdout: {}", out.stdout);
+    assert!(out.stderr.is_empty(), "nothing on stderr: {:?}", out.stderr);
+    assert_eq!(out.code, 0);
+}
+
+#[test]
+fn usage_errors_go_to_stderr() {
+    let root = fixture_warning_only("err-stream");
+    let out = run(&root, &["--nope"]);
+    fs::remove_dir_all(&root).unwrap();
+
+    assert!(out.stderr.contains("Unknown option"), "error on stderr: {}", out.stderr);
+    assert!(out.stdout.is_empty(), "nothing on stdout: {:?}", out.stdout);
+    assert_eq!(out.code, 2);
+}
+
+/// Piping stdout into a reader that closes early must exit cleanly with the conventional
+/// SIGPIPE code (141), never panicking (101) and never masking the failure as success (0).
+/// The fixture is large enough to overflow the OS pipe buffer, so the child genuinely
+/// blocks on a write and hits `EPIPE`.
+#[test]
+fn broken_pipe_exits_141_not_panic() {
+    let root = temp_dir("broken-pipe");
+    // Each finding is well over a hundred bytes; ~3000 of them dwarfs the 64 KB pipe buffer.
+    let mut dockerfile = String::from("FROM node:20\n");
+    for _ in 0..3000 {
+        dockerfile.push_str("RUN npm install\n");
+    }
+    fs::write(root.join("Dockerfile"), dockerfile).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_locked-in"))
+        .arg(&root)
+        .env("NO_COLOR", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+
+    // Read a single byte to ensure the child has started writing, then close the read end.
+    {
+        let mut out = child.stdout.take().expect("piped stdout");
+        let mut one = [0u8; 1];
+        let _ = out.read(&mut one);
+        // `out` drops here, closing the read end while the child is mid-write.
+    }
+    let status = child.wait().expect("wait");
+    fs::remove_dir_all(&root).unwrap();
+
+    assert_eq!(
+        status.code(),
+        Some(141),
+        "broken pipe must exit 141 (not 101 panic, not 0 masking findings)"
+    );
+}


### PR DESCRIPTION
Adds four CLI flags for CI tuning — --quiet, --max-warnings <N>, --fail-on <error|warning>, and --no-summary — plus a --format json mode for machine consumers, so warnings can be hidden or promoted to failures without fragile grep workarounds. Findings now go to stdout while progress/summary go to stderr, and a broken pipe (e.g. locked-in . | head) exits cleanly (141) instead of panicking; other write errors fail loudly rather than truncating silently. Internally, detection logic no longer bakes in user-facing text: rules and the scanner emit a structured ViolationKind, with all message wording moved to a presentation module — making the logic/presentation boundary explicit while keeping output byte-identical. Finally bumps the version to 0.3.2 to cut a release on merge.

Default behavior is unchanged except the intentional stdout/stderr split; verified byte-identical text/JSON output against the prior build